### PR TITLE
Remove call to quit function and switch comparison to use "is"

### DIFF
--- a/vocab_list.py
+++ b/vocab_list.py
@@ -194,7 +194,6 @@ def main():
 			loopon = False
 			driver.close()
 			sys.exit(0)
-			quit()
 		else:
 			print("Running Again!")
 			print()

--- a/vocab_list.py
+++ b/vocab_list.py
@@ -171,7 +171,7 @@ def get_ans():
 
 def main():
 	loopon = True
-	while loopon == True:
+	while loopon is True:
 		global queries
 		words = input("Enter words separated by commas: ")
 		#Trying to fix user input and removing newliens so that it doesn't break


### PR DESCRIPTION
The call to `quit()` is not needed, and is a bug risk. If python is ran with the -S argument, it doesn't exist, and also you already run `sys.exit(0)`, so why call it again?

:)